### PR TITLE
Bugfix: DataDirectory.save() creates file with duplicated file extension

### DIFF
--- a/datatc/data_directory.py
+++ b/datatc/data_directory.py
@@ -89,8 +89,8 @@ class DataDirectory:
 
     def save_file(self, data: Any, file_name: str) -> None:
         data_interface = DataInterfaceManager.select(file_name)
-        data_interface.save(data, file_name, self.path)
-        self.contents[file_name] = DataFile(Path(self.path, file_name))
+        saved_file_path = data_interface.save(data, file_name, self.path)
+        self.contents[file_name] = DataFile(saved_file_path)
 
     def transform_and_save(self, data: Any, transformer_func: Callable, file_name: str, enforce_clean_git=True) -> None:
         new_transform_dir_path = TransformedDataInterface.save(data, transformer_func, parent_path=self.path,

--- a/datatc/data_directory.py
+++ b/datatc/data_directory.py
@@ -222,9 +222,12 @@ class TransformedDataDirectory(DataDirectory):
         """Load a saved data transformer- the data and the function that generated it."""
         return TransformedDataInterface.load(self.path, data_interface_hint, load_function)
 
+    def get_info(self):
+        return TransformedDataInterface.get_info(self.path)
+
     def _build_ls_tree(self, full: bool = False, top_dir: bool = True) -> Dict[str, List]:
         info = TransformedDataInterface.get_info(self.path)
-        ls_description = '{}.{}'.format(info['tag'], info['data_type'])
+        ls_description = '{}.{}  ({})'.format(info['tag'], info['data_type'], info['timestamp'])
         return {ls_description: []}
 
 

--- a/datatc/data_interface.py
+++ b/datatc/data_interface.py
@@ -99,7 +99,7 @@ class CSVDataInterface(DataInterfaceBase):
 
     @classmethod
     def _interface_specific_save(cls, data, file_path, mode=None):
-        data.to_csv(file_path)
+        data.to_csv(file_path, index=False)
 
     @classmethod
     def _interface_specific_load(cls, file_path):

--- a/datatc/data_interface.py
+++ b/datatc/data_interface.py
@@ -40,7 +40,7 @@ class DataInterfaceBase:
         file_path = Path(file_path)
         if not file_path.exists():
             raise FileNotFoundError(file_path)
-        return cls._interface_specific_load(file_path)
+        return cls._interface_specific_load(str(file_path))
 
     @classmethod
     def _interface_specific_load(cls, file_path) -> Any:
@@ -151,6 +151,7 @@ class YAMLDataInterface(DataInterfaceBase):
 
 
 class TestingDataInterface(DataInterfaceBase):
+    """Test class that doesn't make interactions with the file system, for use in unit tests"""
 
     file_extension = 'test'
 
@@ -174,6 +175,8 @@ class DataInterfaceManager:
         'sql': TextDataInterface,
         'pdf': PDFDataInterface,
         'yaml': YAMLDataInterface,
+
+        # for unit testing purposes only
         'test': TestingDataInterface,
     }
 

--- a/tests/test_data_directory.py
+++ b/tests/test_data_directory.py
@@ -121,3 +121,20 @@ class TestDataDirectory(unittest.TestCase):
     def test_latest_empty_dir_returns_none(self):
         data_dir = DataDirectory('top', contents={})
         self.assertEqual(data_dir.latest(), None)
+
+    # === SAVE ===
+
+    def test_save_file_adds_to_dir_contents(self):
+        initial_directory_contents = {}
+        file_name = 'file.test'
+        expected_file_path = '$HOME/{}'.format(file_name)
+        expected_directory_contents_after_save = {file_name: DataFile(expected_file_path)}
+
+        data_directory = DataDirectory(path='$HOME', contents=initial_directory_contents)
+        data_directory.save_file(42, file_name)
+
+        # check that the contents keys (the file names) are the same
+        self.assertEqual(data_directory.contents.keys(), expected_directory_contents_after_save.keys())
+        # check that the contents values are type DataFiles
+        for k in expected_directory_contents_after_save:
+            self.assertEqual(type(data_directory.contents[k]), DataFile)

--- a/tests/test_data_interface.py
+++ b/tests/test_data_interface.py
@@ -1,0 +1,17 @@
+import unittest
+from datatc.data_interface import TestingDataInterface
+
+
+class TestDataInterface(unittest.TestCase):
+
+    def test_construct_file_path_name_without_extension(self):
+        file_name = 'file'
+        file_dir_path = '/home'
+        expected_result = '/home/file.test'
+        self.assertEqual(TestingDataInterface.construct_file_path(file_name, file_dir_path), expected_result)
+
+    def test_construct_file_path_name_with_extension(self):
+        file_name = 'file.yaml'
+        file_dir_path = '/home'
+        expected_result = '/home/file.yaml'
+        self.assertEqual(TestingDataInterface.construct_file_path(file_name, file_dir_path), expected_result)


### PR DESCRIPTION
* `DataInterfaceBase` now checks if there is a file extension in the passed file_name, and only adds file extension if it's not already there. 
* `DataDirectory.save()` adds entry to `DataDirectory.contents`, so user doesn't have to `reload()` to see the freshly saved file.

Unrelated:
* Display timestamp of `TransformedDataDirectory` in `DataDirectory.ls()` 
* Store git hash and time stamp in `SavedDataTransform` in `info` attribute. This information is also accessible from `TransformedDataDirectory.get_info()`. 
* Also changed behavior of `CSVDataInterface` to not save the dataframe index.