### PR TITLE
Bugfix: SavedDataTransform stamps git hash of transform_func

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,32 @@
 # data-traffic-control
 Whhrrrr... Voooooosh... That's the sound of your data coming and going exactly where it belongs
 
-## Usage
+## Contents
+- [Installation](##Installation)
+- [Import](##Import)
+- [Register a project with `DataManager`](##Register-a-project-with-DataManager)
+- [Explore the data directory](##Explore-the-data-directory)
+- [Loading data files](##Loading-data-files)
+  - [Shortcuts for loading data files _faster_](###Shortcuts-for-loading-data-files-faster)
+  - [Loading irregular data files](###Loading-irregular-data-files)
+- [Saving and Loading `SavedDataTransforms`](##Saving-and-Loading-SavedDataTransforms)
+  - [ Automatic Metadata Tracking of `SavedDataTransforms`](###Automatic-Metadata-Tracking-of-SavedDataTransforms)
+  - [ Note on Tracking Git Metadata](###Note-on-Tracking-Git-Metadata)
+  - [ Loading SavedDataTransforms in dependency-incomplete environments](###Loading-SavedDataTransforms-in-dependency-incomplete-environments)
+- [Working with File Types via `DataInterface`](##Working-with-File-Types-via-DataInterface)
 
-### Installation
+## Installation
 
 Clone this repo, `cd` into the newly created `data-traffic-control` directory, and run `pip install -e .` to install the `datatc` package.
 
-### Import
+## Import
+There's only one import you'll need from datatc:
 
 ```python
 from datatc import DataManager
 ```
 
-### Register a project
+## Register a project with `DataManager`
 `datatc` will remember for you where the data for each of your projects is stored, so that you don't have to. The first time you use `datatc` with a project, register it with `DataManager`. You only have to do this once- `DataManager` saves the information in `~/.data_map.yaml` so you never have to memorize that long file path again. 
 
 ```python
@@ -26,13 +39,14 @@ Example:
 DataManager.register_project('mridle', '/home/user/data/mridle/data')
 ```
 
-### `DataManager`
-
 Once you've registered a project, you can establish a `DataManager` on the fly by referencing it's name.
 
 ```python
 dm = DataManager('mridle')
 ```
+The `DataManager` object, `dm`, will be your gateway to all file discovery, load, and save operations.
+
+## Explore the data directory
 
 `DataManager` makes it easier to interact with your project's data directory. It can print out the file structure:
 
@@ -54,7 +68,7 @@ dm.ls()
 #     query.sql
 ```
 
-You can also print the contents of a subdirectory:
+You can also print the contents of a subdirectory by navigating to it via the `[]` operators:
 ```python
 dm['data_extracts'].ls(full=True)
 
@@ -70,8 +84,7 @@ dm['data_extracts'].ls(full=True)
 #         3_month_export.csv
 ```
 
-
-### Loading data files
+## Loading data files
 
 To load a file, navigate the file system using `[]` operators, and then call `.load()`. 
 
@@ -81,6 +94,7 @@ raw_df = dm['data_extracts']['2020-02-04_Extract_3months']['2020-02-04_Extract_3
 
 Don't worry about what format the file is in- `DataManager` will inutit how to load the file. 
 
+### Shortcuts for loading data files _faster_
 To help you navigate those long finicky file names, `DataManager` provides a `.select('hint')` method to search for files matching a substring. 
 
 The above example could also be accessed with the following command, which navigates to the latest extract directory and selects the xlsx file:
@@ -99,7 +113,7 @@ You can load the latest file or subdirectory within a directory with `.latest()`
 ```python
 raw_df = dm['data_extracts'].latest().select('xlsx').load()
 ```
-
+### Loading irregular data files
 If you ever want to do your own load, and not use the build in `.load()`, you can also use `dm[...]['filename'].path` to get the path to the file for use in a separate loading operation.
 
 If `DataManager` doesn't recognize the file type, you can give it a type hint of which loader to use. For example, `DataManager` doesn't have a specific interface for reading tab separated files, but if you tell it to treat it as a csv, it will load it right up:
@@ -115,7 +129,7 @@ For example, if your csv file is actually pipe separated and has a non-default e
 raw_df = dm['queries']['batch_query.csv'].load(sep='|', encoding='utf-16')
 ```
 
-## Saving and Loading SavedDataTransforms
+## Saving and Loading `SavedDataTransforms`
 `datatc` helps you remember how your datasets were generated. 
 Anytime you want `datatc` to help keep track of what transform function was used to create a dataset,
 pass that transform function and the input data to `.save()`, like this: 
@@ -155,6 +169,7 @@ sdt.view_code()
 more_transformed_df = sdt.rerun(new_df)
 ```
 
+### Automatic Metadata Tracking of `SavedDataTransforms`
 `datatc` also automatically tracks metadata about the data transformation, including:
 * the timestamp of when the transformation was run
 * the git hash of the repo where `transform_func` is located
@@ -179,7 +194,7 @@ dm['feature_sets'].latest().get_info()
 }
 ```
 
-### Tracking Git Metadata
+### Note on Tracking Git Metadata
 By default, when you save a transformed dataset via a `transform_func`, `datatc` will include the git hash of the repo where `transform_func` is located.
 This workflow assumes that the `transform_func` is written in a file and imported into the active coding environment for use in a `SavedDataTransform`
 If the `transform_func` is not in a file (for example, is written on the fly in a notebook or in an interactive session),

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If `DataManager` doesn't recognize the file type, you can give it a type hint of
 raw_df = dm['queries']['batch_query.tsv'].load(data_interface_hint='csv')
 ```
 
-Also, if your file needs special parameters to load it, pecify them in the load, and they will be passed on to the loading function.
+Also, if your file needs special parameters to load it, specify them in `load`, and they will be passed on to the internal loading function.
 For example, if your csv file is actually pipe separated and has a non-default encoding, you can specify so:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ Whhrrrr... Voooooosh... That's the sound of your data coming and going exactly w
   - [Shortcuts for loading data files _faster_](#Shortcuts-for-loading-data-files-faster)
   - [Loading irregular data files](#Loading-irregular-data-files)
 - [Saving and Loading `SavedDataTransforms`](#Saving-and-Loading-SavedDataTransforms)
-  - [ Automatic Metadata Tracking of `SavedDataTransforms`](#Automatic-Metadata-Tracking-of-SavedDataTransforms)
-  - [ Note on Tracking Git Metadata](#Note-on-Tracking-Git-Metadata)
-  - [ Loading SavedDataTransforms in dependency-incomplete environments](#Loading-SavedDataTransforms-in-dependency-incomplete-environments)
+  - [`SavedDataTransforms` automatically track metadata](#SavedDataTransforms-automatically-track-metadata)
 - [Working with File Types via `DataInterface`](#Working-with-File-Types-via-DataInterface)
 
 ## Installation
@@ -95,6 +93,7 @@ raw_df = dm['data_extracts']['2020-02-04_Extract_3months']['2020-02-04_Extract_3
 Don't worry about what format the file is in- `DataManager` will inutit how to load the file. 
 
 ### Shortcuts for loading data files _faster_
+#### `select`
 To help you navigate those long finicky file names, `DataManager` provides a `.select('hint')` method to search for files matching a substring. 
 
 The above example could also be accessed with the following command, which navigates to the latest extract directory and selects the xlsx file:
@@ -109,27 +108,30 @@ or even:
 raw_df = dm['data_extracts'].select('2020-01-13').select('xlsx').load()
 ```
 
+#### `latest`
 You can load the latest file or subdirectory within a directory with `.latest()`:
 ```python
 raw_df = dm['data_extracts'].latest().select('xlsx').load()
 ```
 ### Loading irregular data files
-If you ever want to do your own load, and not use the build in `.load()`, you can also use `dm[...]['filename'].path` to get the path to the file for use in a separate loading operation.
-
-If `DataManager` doesn't recognize the file type, you can give it a type hint of which loader to use. For example, `DataManager` doesn't have a specific interface for reading tab separated files, but if you tell it to treat it as a csv, it will load it right up:
-
-```python
-raw_df = dm['queries']['batch_query.tsv'].load(data_interface_hint='csv')
-```
-
-Also, if your file needs special parameters to load it, specify them in `load`, and they will be passed on to the internal loading function.
+#### ... my file needs special arguments to load
+If your file needs special parameters to load it, specify them in `load`, and they will be passed on to the internal loading function.
 For example, if your csv file is actually pipe separated and has a non-default encoding, you can specify so:
 
 ```python
 raw_df = dm['queries']['batch_query.csv'].load(sep='|', encoding='utf-16')
 ```
+#### ... my file type isn't recognized by `DataManager`
+If `DataManager` doesn't recognize the file type, you can give it a type hint of which loader to use. For example, `DataManager` doesn't have a specific interface for reading tab separated files, but if you tell it to treat it as a csv, it will load it right up:
+
+```python
+raw_df = dm['queries']['batch_query.tsv'].load(data_interface_hint='csv')
+```
+#### ... I want to load my file my own way
+If you ever want to do your own load, and not use the build in `.load()`, you can also use `dm[...]['filename'].path` to get the path to the file for use in a separate loading operation.
 
 ## Saving and Loading `SavedDataTransforms`
+### Save
 `datatc` helps you remember how your datasets were generated. 
 Anytime you want `datatc` to help keep track of what transform function was used to create a dataset,
 pass that transform function and the input data to `.save()`, like this: 
@@ -155,6 +157,7 @@ This line of code:
   * saves the result as `my_feature_set.csv`
   * also stamps the code contained in `my_transform` alongside the dataset for easy future reference
 
+### Load
 Afterwards, you can not only load the dataset, but also view and re-use the code that generated that dataset:
 ```python
 sdt = dm['feature_sets'].latest().load()
@@ -169,7 +172,7 @@ sdt.view_code()
 more_transformed_df = sdt.rerun(new_df)
 ```
 
-### Automatic Metadata Tracking of `SavedDataTransforms`
+### `SavedDataTransforms` automatically track metadata
 `datatc` also automatically tracks metadata about the data transformation, including:
 * the timestamp of when the transformation was run
 * the git hash of the repo where `transform_func` is located

--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ sdt.view_code()
 more_transformed_df = sdt.rerun(new_df)
 ```
 
+### Tracking Git Metadata
+By default, when you save a transformed dataset via a `transform_func`, `datatc` will include the git hash of the repo where `transform_func` is located.
+This workflow assumes that the `transform_func` is written in a file and imported into the active coding environment for use in a `SavedDataTransform`
+If the `transform_func` is not in a file (for example, is written on the fly in a notebook or in an interactive session),
+the user may specify the module under development to get a git hash from via `get_git_hash_from=module`.
+
+To ensure tracability, `datatc` checks that there are no uncommitted changes in the repo before proceeding with the SavedDataTransform.
+If there are uncommitted changes, `datatc` raises a `RuntimeError`. If you would like to override this check, specify ``enforce_clean_git = False`.
+
+### Loading SavedDataTransforms in dependency-incomplete environments
+
 If the Saved Data Transform is moved to a different environment where the dependencies for the code transform are not met,
 use
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 Whhrrrr... Voooooosh... That's the sound of your data coming and going exactly where it belongs
 
 ## Contents
-- [Installation](##Installation)
-- [Import](##Import)
-- [Register a project with `DataManager`](##Register-a-project-with-DataManager)
-- [Explore the data directory](##Explore-the-data-directory)
-- [Loading data files](##Loading-data-files)
-  - [Shortcuts for loading data files _faster_](###Shortcuts-for-loading-data-files-faster)
-  - [Loading irregular data files](###Loading-irregular-data-files)
-- [Saving and Loading `SavedDataTransforms`](##Saving-and-Loading-SavedDataTransforms)
-  - [ Automatic Metadata Tracking of `SavedDataTransforms`](###Automatic-Metadata-Tracking-of-SavedDataTransforms)
-  - [ Note on Tracking Git Metadata](###Note-on-Tracking-Git-Metadata)
-  - [ Loading SavedDataTransforms in dependency-incomplete environments](###Loading-SavedDataTransforms-in-dependency-incomplete-environments)
-- [Working with File Types via `DataInterface`](##Working-with-File-Types-via-DataInterface)
+- [Installation](#Installation)
+- [Import](#Import)
+- [Register a project with `DataManager`](#Register-a-project-with-DataManager)
+- [Explore the data directory](#Explore-the-data-directory)
+- [Loading data files](#Loading-data-files)
+  - [Shortcuts for loading data files _faster_](#Shortcuts-for-loading-data-files-faster)
+  - [Loading irregular data files](#Loading-irregular-data-files)
+- [Saving and Loading `SavedDataTransforms`](#Saving-and-Loading-SavedDataTransforms)
+  - [ Automatic Metadata Tracking of `SavedDataTransforms`](#Automatic-Metadata-Tracking-of-SavedDataTransforms)
+  - [ Note on Tracking Git Metadata](#Note-on-Tracking-Git-Metadata)
+  - [ Loading SavedDataTransforms in dependency-incomplete environments](#Loading-SavedDataTransforms-in-dependency-incomplete-environments)
+- [Working with File Types via `DataInterface`](#Working-with-File-Types-via-DataInterface)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ sdt.view_code()
 more_transformed_df = sdt.rerun(new_df)
 ```
 
-`datatc` also automatically tracks metadata about the data transofrmation, including:
+`datatc` also automatically tracks metadata about the data transformation, including:
 * the timestamp of when the transformation was run
 * the git hash of the repo where `transform_func` is located
 

--- a/datatc/data_directory.py
+++ b/datatc/data_directory.py
@@ -229,7 +229,7 @@ class TransformedDataDirectory(DataDirectory):
 
     def _build_ls_tree(self, full: bool = False, top_dir: bool = True) -> Dict[str, List]:
         info = TransformedDataInterface.get_info(self.path)
-        ls_description = '{}.{}  ({})'.format(info['tag'], info['data_type'], info['timestamp'])
+        ls_description = '{}.{}  ({}, {})'.format(info['tag'], info['data_type'], info['timestamp'], info['git_hash'])
         return {ls_description: []}
 
 

--- a/datatc/data_directory.py
+++ b/datatc/data_directory.py
@@ -79,22 +79,24 @@ class DataDirectory:
         latest_content = sorted_contents[-1]
         return self.contents[latest_content]
 
-    def save(self, data: Any, file_name: str, transformer_func: Callable = None, enforce_clean_git: bool = True
-             ) -> None:
+    def save(self, data: Any, file_name: str, transformer_func: Callable = None, enforce_clean_git: bool = True,
+             get_git_hash_from: Any = None) -> None:
 
         if transformer_func is None:
             self.save_file(data, file_name)
         else:
-            self.transform_and_save(data, transformer_func, file_name, enforce_clean_git)
+            self.transform_and_save(data, transformer_func, file_name, enforce_clean_git, get_git_hash_from)
 
     def save_file(self, data: Any, file_name: str) -> None:
         data_interface = DataInterfaceManager.select(file_name)
         saved_file_path = data_interface.save(data, file_name, self.path)
         self.contents[file_name] = DataFile(saved_file_path)
 
-    def transform_and_save(self, data: Any, transformer_func: Callable, file_name: str, enforce_clean_git=True) -> None:
+    def transform_and_save(self, data: Any, transformer_func: Callable, file_name: str, enforce_clean_git=True,
+                           get_git_hash_from: Any = None) -> None:
         new_transform_dir_path = TransformedDataInterface.save(data, transformer_func, parent_path=self.path,
-                                                               file_name=file_name, enforce_clean_git=enforce_clean_git)
+                                                               file_name=file_name, enforce_clean_git=enforce_clean_git,
+                                                               get_git_hash_from=get_git_hash_from)
         base_name = os.path.basename(new_transform_dir_path)
         self.contents[base_name] = TransformedDataDirectory(new_transform_dir_path)
         return

--- a/datatc/data_interface.py
+++ b/datatc/data_interface.py
@@ -15,12 +15,12 @@ class DataInterfaceBase:
     file_extension = None
 
     @classmethod
-    def save(cls, data: Any, file_name: str, file_dir_path: str, mode: str = None) -> str:
+    def save(cls, data: Any, file_name: str, file_dir_path: str, mode: str = None, **kwargs) -> str:
         file_path = cls.construct_file_path(file_name, file_dir_path)
         if mode is None:
-            cls._interface_specific_save(data, file_path)
+            cls._interface_specific_save(data, file_path, **kwargs)
         else:
-            cls._interface_specific_save(data, file_path, mode)
+            cls._interface_specific_save(data, file_path, mode, **kwargs)
         return file_path
 
     @classmethod
@@ -32,18 +32,18 @@ class DataInterfaceBase:
             return str(Path(file_dir_path, file_name))
 
     @classmethod
-    def _interface_specific_save(cls, data: Any, file_path, mode: str = None) -> None:
+    def _interface_specific_save(cls, data: Any, file_path, mode: str = None, **kwargs) -> None:
         raise NotImplementedError
 
     @classmethod
-    def load(cls, file_path: str) -> Any:
+    def load(cls, file_path: str, **kwargs) -> Any:
         file_path = Path(file_path)
         if not file_path.exists():
             raise FileNotFoundError(file_path)
-        return cls._interface_specific_load(str(file_path))
+        return cls._interface_specific_load(str(file_path), **kwargs)
 
     @classmethod
-    def _interface_specific_load(cls, file_path) -> Any:
+    def _interface_specific_load(cls, file_path, **kwargs) -> Any:
         raise NotImplementedError
 
 
@@ -52,13 +52,13 @@ class TextDataInterface(DataInterfaceBase):
     file_extension = 'txt'
 
     @classmethod
-    def _interface_specific_save(cls, data, file_path, mode='w'):
-        with open(file_path, mode) as f:
+    def _interface_specific_save(cls, data, file_path, mode='w', **kwargs):
+        with open(file_path, mode, **kwargs) as f:
             f.write(data)
 
     @classmethod
-    def _interface_specific_load(cls, file_path):
-        with open(file_path, 'r') as f:
+    def _interface_specific_load(cls, file_path, **kwargs):
+        with open(file_path, 'r', **kwargs) as f:
             file = f.read()
         return file
 
@@ -68,13 +68,13 @@ class PickleDataInterface(DataInterfaceBase):
     file_extension = 'pkl'
 
     @classmethod
-    def _interface_specific_save(cls, data: Any, file_path, mode='wb+') -> None:
-        with open(file_path, mode) as f:
+    def _interface_specific_save(cls, data: Any, file_path, mode='wb+', **kwargs) -> None:
+        with open(file_path, mode, **kwargs) as f:
             pickle.dump(data, f)
 
     @classmethod
-    def _interface_specific_load(cls, file_path) -> Any:
-        with open(file_path, "rb+") as f:
+    def _interface_specific_load(cls, file_path, **kwargs) -> Any:
+        with open(file_path, "rb+", **kwargs) as f:
             return pickle.load(f)
 
 
@@ -83,13 +83,13 @@ class DillDataInterface(DataInterfaceBase):
     file_extension = 'dill'
 
     @classmethod
-    def _interface_specific_save(cls, data: Any, file_path, mode='wb+') -> None:
-        with open(file_path, mode) as f:
+    def _interface_specific_save(cls, data: Any, file_path, mode='wb+', **kwargs) -> None:
+        with open(file_path, mode, **kwargs) as f:
             dill.dump(data, f)
 
     @classmethod
-    def _interface_specific_load(cls, file_path) -> Any:
-        with open(file_path, "rb+") as f:
+    def _interface_specific_load(cls, file_path, **kwargs) -> Any:
+        with open(file_path, "rb+", **kwargs) as f:
             return dill.load(f)
 
 
@@ -98,12 +98,12 @@ class CSVDataInterface(DataInterfaceBase):
     file_extension = 'csv'
 
     @classmethod
-    def _interface_specific_save(cls, data, file_path, mode=None):
-        data.to_csv(file_path, index=False)
+    def _interface_specific_save(cls, data, file_path, mode=None, **kwargs):
+        data.to_csv(file_path, **kwargs)
 
     @classmethod
-    def _interface_specific_load(cls, file_path):
-        return pd.read_csv(file_path)
+    def _interface_specific_load(cls, file_path, **kwargs):
+        return pd.read_csv(file_path, **kwargs)
 
 
 class ExcelDataInterface(DataInterfaceBase):
@@ -111,12 +111,12 @@ class ExcelDataInterface(DataInterfaceBase):
     file_extension = 'xlsx'
 
     @classmethod
-    def _interface_specific_save(cls, data, file_path, mode=None):
-        data.to_excel(file_path)
+    def _interface_specific_save(cls, data, file_path, mode=None, **kwargs):
+        data.to_excel(file_path, **kwargs)
 
     @classmethod
-    def _interface_specific_load(cls, file_path):
-        return pd.read_excel(file_path)
+    def _interface_specific_load(cls, file_path, **kwargs):
+        return pd.read_excel(file_path, **kwargs)
 
 
 class PDFDataInterface(DataInterfaceBase):
@@ -124,13 +124,13 @@ class PDFDataInterface(DataInterfaceBase):
     file_extension = 'pdf'
 
     @classmethod
-    def _interface_specific_save(cls, doc, file_path, mode=None):
-        doc.save(file_path, garbage=4, deflate=True, clean=True)
+    def _interface_specific_save(cls, doc, file_path, mode=None, **kwargs):
+        doc.save(file_path, garbage=4, deflate=True, clean=True, **kwargs)
 
     @classmethod
-    def _interface_specific_load(cls, file_path):
+    def _interface_specific_load(cls, file_path, **kwargs):
         import fitz
-        return fitz.open(file_path)
+        return fitz.open(file_path, **kwargs)
 
 
 class YAMLDataInterface(DataInterfaceBase):
@@ -138,14 +138,13 @@ class YAMLDataInterface(DataInterfaceBase):
     file_extension = 'yaml'
 
     @classmethod
-    def _interface_specific_save(cls, data, file_path, mode='w'):
-        # TODO: make mode an arg in all saves
-        with open(file_path, mode) as f:
+    def _interface_specific_save(cls, data, file_path, mode='w', **kwargs):
+        with open(file_path, mode, **kwargs) as f:
             yaml.dump(data, f, default_flow_style=False)
 
     @classmethod
-    def _interface_specific_load(cls, file_path):
-        with open(file_path, 'r') as f:
+    def _interface_specific_load(cls, file_path, **kwargs):
+        with open(file_path, 'r', **kwargs) as f:
             data = yaml.safe_load(f)
         return data
 
@@ -156,11 +155,11 @@ class TestingDataInterface(DataInterfaceBase):
     file_extension = 'test'
 
     @classmethod
-    def _interface_specific_save(cls, data, file_path, mode='wb+') -> None:
+    def _interface_specific_save(cls, data, file_path, mode='wb+', **kwargs) -> None:
         return
 
     @classmethod
-    def _interface_specific_load(cls, file_path):
+    def _interface_specific_load(cls, file_path, **kwargs):
         return {'data': 42}
 
 

--- a/datatc/data_transformer.py
+++ b/datatc/data_transformer.py
@@ -42,7 +42,7 @@ class TransformedData:
 
     @classmethod
     def save(cls, data: Any, transformer_func: Callable, data_directory: 'DataDirectory', file_name: str,
-             enforce_clean_git: bool = True, get_git_hash_from: Any = None) -> Path:
+             enforce_clean_git: bool = True, get_git_hash_from: Any = None, **kwargs) -> Path:
         """
         Alternative public method for saving a TransformedData.
 
@@ -54,10 +54,11 @@ class TransformedData:
         """
         # TODO: convert DataDirectory to path/str
         return TransformedDataInterface.save(data, transformer_func, data_directory, file_name, enforce_clean_git,
-                                             get_git_hash_from)
+                                             get_git_hash_from, **kwargs)
 
     @classmethod
-    def load(cls, transformed_data_dir: 'TransformedDataDirectory', data_interface_hint=None) -> 'TransformedData':
+    def load(cls, transformed_data_dir: 'TransformedDataDirectory', data_interface_hint=None, **kwargs
+             ) -> 'TransformedData':
         """
         Alternative public method for loading a TransformedData.
 
@@ -66,7 +67,7 @@ class TransformedData:
             fe_dir = dm['feature_engineering'].latest()
             TransformedData.load(fe_dir)
         """
-        return TransformedDataInterface.load(transformed_data_dir, data_interface_hint)
+        return TransformedDataInterface.load(transformed_data_dir, data_interface_hint, **kwargs)
 
 
 class TransformedDataInterface:
@@ -79,7 +80,7 @@ class TransformedDataInterface:
 
     @classmethod
     def save(cls, data: Any, transformer_func: Callable, parent_path: str, file_name: str, enforce_clean_git=True,
-             get_git_hash_from: Any = None) -> Path:
+             get_git_hash_from: Any = None, **kwargs) -> Path:
         """
         Save a transformed dataset.
 
@@ -117,7 +118,7 @@ class TransformedDataInterface:
 
         data_interface = DataInterfaceManager.select(data_file_type)
         data = transformer_func(data)
-        data_interface.save(data, 'data', new_transform_dir_path)
+        data_interface.save(data, 'data', new_transform_dir_path, **kwargs)
 
         cls.file_component_interfaces['func'].save(transformer_func, 'func', new_transform_dir_path)
 
@@ -128,7 +129,7 @@ class TransformedDataInterface:
         return new_transform_dir_path
 
     @classmethod
-    def load(cls, path: str, data_interface_hint=None, load_function: bool = True) -> 'TransformedData':
+    def load(cls, path: str, data_interface_hint=None, load_function: bool = True, **kwargs) -> 'TransformedData':
         """
         Load a saved data transformer- the data and the function that generated it.
 
@@ -147,7 +148,7 @@ class TransformedDataInterface:
         code_file = file_map['code']
 
         data_interface = DataInterfaceManager.select(data_file, default_file_type=data_interface_hint)
-        data = data_interface.load(data_file)
+        data = data_interface.load(data_file, **kwargs)
         if load_function:
             transformer_func = cls.file_component_interfaces['func'].load(func_file)
         else:

--- a/datatc/data_transformer.py
+++ b/datatc/data_transformer.py
@@ -42,7 +42,7 @@ class TransformedData:
 
     @classmethod
     def save(cls, data: Any, transformer_func: Callable, data_directory: 'DataDirectory', file_name: str,
-             enforce_clean_git=True) -> Path:
+             enforce_clean_git: bool = True, get_git_hash_from: Any = None) -> Path:
         """
         Alternative public method for saving a TransformedData.
 
@@ -53,7 +53,8 @@ class TransformedData:
             TransformedData.save(df, transformer, fe_dir, 'v2.csv')
         """
         # TODO: convert DataDirectory to path/str
-        return TransformedDataInterface.save(data, transformer_func, data_directory, file_name, enforce_clean_git)
+        return TransformedDataInterface.save(data, transformer_func, data_directory, file_name, enforce_clean_git,
+                                             get_git_hash_from)
 
     @classmethod
     def load(cls, transformed_data_dir: 'TransformedDataDirectory', data_interface_hint=None) -> 'TransformedData':
@@ -77,9 +78,10 @@ class TransformedDataInterface:
     }
 
     @classmethod
-    def save(cls, data: Any, transformer_func: Callable, parent_path: str, file_name: str, enforce_clean_git=True)\
-            -> Path:
-        """Save a transformed dataset.
+    def save(cls, data: Any, transformer_func: Callable, parent_path: str, file_name: str, enforce_clean_git=True,
+             get_git_hash_from: Any = None) -> Path:
+        """
+        Save a transformed dataset.
 
         Args:
             data: Input data to transform.
@@ -89,9 +91,15 @@ class TransformedDataInterface:
              data as.
             enforce_clean_git: Whether to only allow the save to proceed if the working state of the git directory is
                 clean.
+            get_git_hash_from: Locally installed module from which to get git information. Use this arg if
+                transform_func is defined outside of a module tracked by git.
 
-        Returns: Tuple[new transform directory name, TransformedDataDirectory object], for adding to contents dict."""
-        transformer_func_file_repo_path = get_git_repo_of_func(transformer_func)
+        Returns: Tuple[new transform directory name, TransformedDataDirectory object], for adding to contents dict.
+        """
+        if get_git_hash_from:
+            transformer_func_file_repo_path = get_git_repo_of_func(get_git_hash_from)
+        else:
+            transformer_func_file_repo_path = get_git_repo_of_func(transformer_func)
         transformer_func_in_repo = True if transformer_func_file_repo_path else True
 
         if enforce_clean_git:

--- a/datatc/data_transformer.py
+++ b/datatc/data_transformer.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Tuple
 
 from datatc.data_interface import DataInterfaceManager, DillDataInterface, TextDataInterface
-from datatc.git_utilities import get_git_repo_of_func, check_for_uncommitted_git_changes_at_path, get_git_hash_for_file
+from datatc.git_utilities import get_git_repo_of_func, check_for_uncommitted_git_changes_at_path, get_git_hash
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
@@ -110,7 +110,7 @@ class TransformedDataInterface:
                                    'Use `enforce_clearn_git=False` to override this restriction.')
 
         tag, data_file_type = os.path.splitext(file_name)
-        git_hash = get_git_hash_for_file(transformer_func_file_repo_path) if transformer_func_in_repo else None
+        git_hash = get_git_hash(transformer_func_file_repo_path) if transformer_func_in_repo else None
         transform_dir_name = cls._generate_name_for_transform_dir(tag, git_hash)
         new_transform_dir_path = Path(parent_path, transform_dir_name)
         os.makedirs(new_transform_dir_path)

--- a/datatc/data_transformer.py
+++ b/datatc/data_transformer.py
@@ -94,7 +94,7 @@ class TransformedDataInterface:
             get_git_hash_from: Locally installed module from which to get git information. Use this arg if
                 transform_func is defined outside of a module tracked by git.
 
-        Returns: Tuple[new transform directory name, TransformedDataDirectory object], for adding to contents dict.
+        Returns: new transform directory name, for adding to contents dict.
         """
         if get_git_hash_from:
             transformer_func_file_repo_path = get_git_repo_of_func(get_git_hash_from)

--- a/datatc/git_utilities.py
+++ b/datatc/git_utilities.py
@@ -1,18 +1,54 @@
+import git
 from git import Repo
 import inspect
 import os
 import subprocess
+from typing import Callable
 
 
-def get_git_hash(path: str) -> str:
+def get_git_repo_of_func(func: Callable) -> str:
+    """
+    Determine the directory of the git repo in which the function is defined.
+    If the function is not defined in a file (in a notebook or interactive session), or is defined in a file outside
+         of a git repo, returns None.
+
+    Args:
+        func: A function.
+
+    Returns:
+        If the function is defined in a file inside a git repo, returns the path to the git working tree directory.
+        If the function is not defined in a file (in a notebook or interactive session), or is defined in a file outside
+         of a git repo, returns None.
+
+    """
+    file_path = get_file_where_func_defined(func)
+    if os.path.exists(file_path):
+        if check_if_path_is_in_git_repo(file_path):
+            repo = Repo(file_path, search_parent_directories=True)
+            return repo.working_tree_dir
+    return None
+
+
+def get_file_where_func_defined(func: Callable) -> str:
+    return os.path.abspath(inspect.getfile(func))
+
+
+def check_if_path_is_in_git_repo(path: str) -> bool:
+    try:
+        _ = Repo(path, search_parent_directories=True)
+    except git.exc.InvalidGitRepositoryError:
+        return False
+    return True
+
+
+def get_git_hash(dir_path: str) -> str:
     """
     Get the short hash of latest git commit.
-        path (str): Path to git repo.
+        path (str): Path to directory within a git repo. Does not need to be the top level repo directory.
     Returns:
         git_hash (str): Short hash of latest commit on the active branch of the git repo.
     """
-    git_hash_raw = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
-                                           cwd=path)
+    git_hash_raw = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], cwd=dir_path)
     git_hash = git_hash_raw.strip().decode("utf-8")
     return git_hash
 
@@ -21,8 +57,9 @@ def check_for_uncommitted_git_changes_at_path(repo_path: str) -> bool:
     """
     Check if there are uncommitted changes in the git repo, and raise an error if there are.
     Args:
-        repo_path: str. Path to the repo to check.
-    Returns: bool. False: no uncommitted changes found, Repo is valid.
+        repo_path: str. Path to a directory or file within a Git repository. Does not need to be the top level repo dir.
+    Returns: bool.
+        False: no uncommitted changes found, Repo is valid.
         True: uncommitted changes found. Repo is not valid.
     """
     repo = Repo(repo_path, search_parent_directories=True)
@@ -49,7 +86,3 @@ def check_for_uncommitted_git_changes_at_path(repo_path: str) -> bool:
                            '\nCommit them before proceeding. '.format(', '.join(changed_files)))
 
     return False
-
-
-def get_repo_path():
-    return os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))


### PR DESCRIPTION
Previously, `SavedDataTransform` was stamping the git hash of `datatc`. This PR fixes to stamping the git hash of the file where `transform_func` is defined. 
If `transform_func` is not defined in a git-tracked file, the user may specify the module under development to get a git hash from via `get_git_hash_from=module`. 