### PR TITLE
Bugfix: Can't .select(file_extension) on TransformedDataDirectories

### DIFF
--- a/datatc/data_directory.py
+++ b/datatc/data_directory.py
@@ -234,6 +234,9 @@ class TransformedDataDirectory(DataDirectory):
     def __init__(self, path, contents=None):
         super().__init__(path, contents)
 
+        # Overwrite the name (normally os.path.basename) with effective file name
+        self.name = self._get_printable_filename()
+
     def _determine_data_type(self):
         return TransformedDataInterface.get_info(self.path)['data_type']
 
@@ -254,9 +257,17 @@ class TransformedDataDirectory(DataDirectory):
         return TransformedDataInterface.get_info(self.path)
 
     def _build_ls_tree(self, full: bool = False, top_dir: bool = True) -> Dict[str, List]:
+        printable_filename = self._get_printable_filename()
         info = TransformedDataInterface.get_info(self.path)
-        ls_description = '{}.{}  ({}, {})'.format(info['tag'], info['data_type'], info['timestamp'], info['git_hash'])
+        ls_description = '{}  ({}, {})'.format(printable_filename, info['timestamp'], info['git_hash'])
         return {ls_description: []}
+
+    def _get_printable_filename(self) -> str:
+        """Build the filename that should be printed to describe the TransformedDataDirectory.
+         The filename is created based on the TransformedDataDirectory tag and file type."""
+        info = TransformedDataInterface.get_info(self.path)
+        effective_filename = '{}.{}'.format(info['tag'], info['data_type'])
+        return effective_filename
 
 
 class DataFile(DataDirectory):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='datatc',
-      version='0.0.4',
+      version='0.0.5',
       author="Laura Kinkead",
       description='Automate every-day interactions with your data.',
       long_description=long_description,


### PR DESCRIPTION
**Bug:** If you tried to call `DataDirectory.select(<file_extension>)` on a `TransformedDataDirectory`, the file would not be found.

**Cause:** `select` searches the `DataDirectory.name` property, which is set as `os.path.basename`. For a `TransformedDataDirectory`, the OS base name contains only timestamp, git hash, and the tag, not the file extension. (When you do `DataDirectory.ls()`, you see the filename written as `<tag>.<file_extension>`because under the hood `ls` builds this. `select` does not have access to this same tex.)

**Fix:** Overwrite the `TransformedDataDirectory.name` property to be `<tag>.<file_extension>`, so that `select` searches the same name string as is shown by `ls`. 